### PR TITLE
fix(context-16k): model uses 16k tokens now

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -114,7 +114,7 @@ const openGPTContextPanelCommand = vscode.commands.registerCommand('extension.op
             // Call OpenAI API with the question and file contents
             try {
                 const chatCompletion = await openai.createChatCompletion({
-                    model: "gpt-3.5-turbo",
+                    model: "gpt-3.5-turbo-16k",
                     messages: [
                         { role: "system", content: "Answer the coding questions, only provide the code and documentation, explaining the solution after providing the code." },
                         { role: "user", content: question },


### PR DESCRIPTION
# Model can be changed to reflect a higher token limit

Altered it to use the 16k model by default

![image](https://github.com/Iheuzio/gpt-contextfiles/assets/97270760/c2a4f735-4aa1-4b9c-b6b4-2fc1d497b1ac)
