### PR TITLE
fix(explorer-context): Shows the add files context for any file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-contextfiles",
   "displayName": "GPT-ContextFiles",
   "description": "Choose the files to pass into GPT to provide a question with multiple files (doesn't check context)",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "engines": {
     "vscode": "^1.79.0"
   },
@@ -67,7 +67,7 @@
     "menus": {
       "explorer/context": [
         {
-          "when": "resourceLangId == javascript",
+          "when": "resourceIsFolder == false",
           "command": "extension.addFilesToGPTContext",
           "group": "navigation"
         }


### PR DESCRIPTION
Fix for explorer to now use any file, excluding directories when right click is used. Prior it was solely javascript files