### PR TITLE
fix(display-html): html is now properly displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-contextfiles",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-contextfiles",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "dependencies": {
         "openai": "^3.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-contextfiles",
   "displayName": "GPT-ContextFiles",
   "description": "Choose the files to pass into GPT to provide a question with multiple files",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/gptContext.js
+++ b/src/gptContext.js
@@ -39,7 +39,7 @@ async function handleQuestionSubmission(panel, question, selectedUris) {
         const chatCompletion = await openai.createChatCompletion({
             model: "gpt-3.5-turbo-16k",
             messages: [
-                { role: "system", content: "Answer the coding questions, only provide the code and documentation, explaining the solution after providing the code." },
+                { role: "system", content: "Answer the coding questions, only provide the code and documentation, explaining the solution after providing the code. Put codeblocks inside ``` code ``` with file names above each snippet." },
                 { role: "user", content: question + "\n" + fileContents},
             ],
         });

--- a/src/webviewPanel.js
+++ b/src/webviewPanel.js
@@ -304,13 +304,19 @@ function getWebviewContent(apiResponse = '', question = '') {
                 </div>
                 <div class="content" id="api-response">
                     <div id="question-rep">
-                        <p>${question ? '> ' + question : null}</p>
+                        <p>${
+                            question = question.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+                            question ? '> ' + question : null
+                        }</p>
                     </div>
                     ${
                     apiResponse ? `
                     <div id="rendered">
                         <p id="responses">
-                            <pre id="response">${apiResponse.replace(/```([^```]+)```/g, '<div  id="code-block"><code>$1</code><button onclick="copyCode(event)" id="copy-button">copy</button></div>')}</pre>
+                            <pre id="response">${
+                                apiResponse = apiResponse.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+                                apiResponse.replace(/```([^```]+)```/g, '<div  id="code-block"><code>$1</code><button onclick="copyCode(event)" id="copy-button">copy</button></div>')
+                            }</pre>
                         </p>
                     </div>
                     ` : null


### PR DESCRIPTION
closes #37 
html tags previously were rendered in the tab, now replaced them with &lt and &gt so it can work in the response.

![image](https://github.com/Iheuzio/gpt-contextfiles/assets/97270760/c5b6fecc-323d-41e1-be3a-4a34176f19c4)
